### PR TITLE
fixes crash when using contourf with extend option and changing contourf levels to represent a range.

### DIFF
--- a/geojsoncontour/contour.py
+++ b/geojsoncontour/contour.py
@@ -70,7 +70,8 @@ def contourf_to_geojson(contourf, geojson_filepath=None, min_angle_deg=None,
                         geojson_properties=None, strdump=False, serialize=True):
     """Transform matplotlib.contourf to geojson with MultiPolygons."""
     polygon_features = []
-    for coll, level in zip(contourf.collections, contourf.levels):
+    contourf_levels = get_contourf_levels(contourf.levels,contourf.extend)
+    for coll, level in zip(contourf.collections, contourf_levels):
         color = coll.get_facecolor()
         muli = MP(coll, min_angle_deg, ndigits)
         polygon = muli.mpoly()

--- a/geojsoncontour/contour.py
+++ b/geojsoncontour/contour.py
@@ -5,7 +5,7 @@ import numpy as np
 from matplotlib.colors import rgb2hex
 from geojson import Feature, LineString
 from geojson import Polygon, FeatureCollection
-from .utilities.multipoly import MP, keep_high_angle, set_contourf_properties
+from .utilities.multipoly import MP, keep_high_angle, set_contourf_properties,get_contourf_levels
 
 
 def contour_to_geojson(contour, geojson_filepath=None, min_angle_deg=None,
@@ -45,6 +45,7 @@ def contourf_to_geojson_overlap(contourf, geojson_filepath=None, min_angle_deg=N
     """Transform matplotlib.contourf to geojson with overlapping filled contours."""
     polygon_features = []
     contourf_idx = 0
+    contourf_levels =  get_contourf_levels(contourf.levels,contourf.extend)
     for collection in contourf.collections:
         color = collection.get_facecolor()
         for path in collection.get_paths():
@@ -54,7 +55,7 @@ def contourf_to_geojson_overlap(contourf, geojson_filepath=None, min_angle_deg=N
                 coord = np.around(coord, ndigits) if ndigits else coord
                 polygon = Polygon(coordinates=[coord.tolist()])
                 fcolor = rgb2hex(color[0])
-                properties = set_contourf_properties(stroke_width, fcolor, fill_opacity, contourf.levels[contourf_idx], unit)
+                properties = set_contourf_properties(stroke_width, fcolor, fill_opacity, contourf_levels[contourf_idx], unit)
                 if geojson_properties:
                     properties.update(geojson_properties)
                 feature = Feature(geometry=polygon, properties=properties)

--- a/geojsoncontour/utilities/multipoly.py
+++ b/geojsoncontour/utilities/multipoly.py
@@ -64,5 +64,25 @@ def set_contourf_properties(stroke_width, fcolor, fill_opacity, level, unit):
         "stroke-opacity": 1,
         "fill": fcolor,
         "fill-opacity": fill_opacity,
-        "title": "%.2f" % level + ' ' + unit
+        "title": "%s" % level + ' ' + unit
     }
+
+
+def get_contourf_levels(levels,extend):
+
+    mid_levels=[]
+
+    for i in range(len(levels)-1):
+
+        mid_levels.append(f'{levels[i]}-{levels[i+1]}')
+
+    if extend=='both':
+        return ["<%.2f" % levels[0],*mid_levels ,">%.2f" % levels[-1]]
+    elif extend=='max':
+        return [*mid_levels ,">%.2f" % levels[-1]]
+    elif extend=='min':
+        return ["<%.2f" % levels[0],*mid_levels]
+    else:
+        return mid_levels
+            
+

--- a/geojsoncontour/utilities/multipoly.py
+++ b/geojsoncontour/utilities/multipoly.py
@@ -70,11 +70,7 @@ def set_contourf_properties(stroke_width, fcolor, fill_opacity, level, unit):
 
 def get_contourf_levels(levels,extend):
 
-    mid_levels=[]
-
-    for i in range(len(levels)-1):
-
-        mid_levels.append(f'{levels[i]}-{levels[i+1]}')
+    mid_levels=[ "%.2f" % levels[i] + '-' + "%.2f" % levels[i+1] for i in range(len(levels)-1) ]
 
     if extend=='both':
         return ["<%.2f" % levels[0],*mid_levels ,">%.2f" % levels[-1]]


### PR DESCRIPTION
Using contourf_to_geojson_overlap with extend="both"  in matplotlib contourf causes crash because this creates  n+1 contour levels thus for last polygon no level existes in countourf.levels list. Also in  case of coutourf plot the colors represent range. According to  matplotlib documentation if defined levels are [1,5] then this will produce one filled contour with  1<fill_color <=5 level. If used with extend="max" the contour levels will be <=1, >1 to <=5, >5. This pull request tries to fix this issue.