### PR TITLE
Add option for variable fill opacity in contourf_to_geojson()

### DIFF
--- a/geojsoncontour/contour.py
+++ b/geojsoncontour/contour.py
@@ -65,9 +65,16 @@ def contourf_to_geojson_overlap(contourf, geojson_filepath=None, min_angle_deg=N
 
 
 def contourf_to_geojson(contourf, geojson_filepath=None, min_angle_deg=None,
-                        ndigits=5, unit='', stroke_width=1, fill_opacity=.9,
+                        ndigits=5, unit='', stroke_width=1, fill_opacity=.9, fill_opacity_range=None,
                         geojson_properties=None, strdump=False, serialize=True):
     """Transform matplotlib.contourf to geojson with MultiPolygons."""
+    if fill_opacity_range:
+        variable_opacity = True
+        min_opacity, max_opacity = fill_opacity_range
+        opacity_increment = (max_opacity - min_opacity) / len(contourf.levels)
+        fill_opacity = min_opacity
+    else:
+        variable_opacity = False
     polygon_features = []
     for coll, level in zip(contourf.collections, contourf.levels):
         color = coll.get_facecolor()
@@ -79,6 +86,8 @@ def contourf_to_geojson(contourf, geojson_filepath=None, min_angle_deg=None,
             properties.update(geojson_properties)
         feature = Feature(geometry=polygon, properties=properties)
         polygon_features.append(feature)
+        if variable_opacity:
+            fill_opacity += opacity_increment
     feature_collection = FeatureCollection(polygon_features)
     return _render_feature_collection(feature_collection, geojson_filepath, strdump, serialize)
 


### PR DESCRIPTION
I added an option to specify a range of fill opacity values in `contourf_to_geojson()` (via the `fill_opacity_range` argument). It is a tuple of two numbers, min and max. The fill opacity is linearly interpolated from the range based on the contour levels. Lower contour levels have lower opacity.  By default `fill_opacity_range` is set to `None`, hence ignored if it’s not specified. If `fill_opacity_range` is specified, `fill_opacity` is ignored.

This could be useful for cases where it is important to highlight the higher contours (example below).

| Constant fill opacity | Variable fill opacity |
|---|---|
| ![Untitled](https://user-images.githubusercontent.com/36637689/85233793-f1ec0d00-b400-11ea-81c6-37d0f733c1fc.png) | ![Untitled(1)](https://user-images.githubusercontent.com/36637689/85233799-0203ec80-b401-11ea-946e-014def2a4faa.png) |


