### PR TITLE
Do not add a feature if the polygon is empty. Do not an empty polygon…

### DIFF
--- a/geojsoncontour/contour.py
+++ b/geojsoncontour/contour.py
@@ -83,13 +83,15 @@ def contourf_to_geojson(contourf, geojson_filepath=None, min_angle_deg=None,
         muli = MP(coll, min_angle_deg, ndigits)
         polygon = muli.mpoly()
         fcolor = rgb2hex(color[0])
-        properties = set_contourf_properties(stroke_width, fcolor, fill_opacity, level, unit)
-        if geojson_properties:
-            properties.update(geojson_properties)
-        feature = Feature(geometry=polygon, properties=properties)
-        polygon_features.append(feature)
-        if variable_opacity:
-            fill_opacity += opacity_increment
+        if polygon.coordinates:
+            properties = set_contourf_properties(stroke_width, fcolor, fill_opacity, level, unit)
+            if geojson_properties:
+                properties.update(geojson_properties)
+            feature = Feature(geometry=polygon, properties=properties)
+            polygon_features.append(feature)
+            # print(len(polygon.coordinates))
+            if variable_opacity:
+                fill_opacity += opacity_increment
     feature_collection = FeatureCollection(polygon_features)
     return _render_feature_collection(feature_collection, geojson_filepath, strdump, serialize)
 

--- a/geojsoncontour/utilities/multipoly.py
+++ b/geojsoncontour/utilities/multipoly.py
@@ -21,7 +21,8 @@ class MP(object):
                 if ndigits:
                     linestring = np.around(linestring, ndigits)
                 polygon.append(linestring.tolist())
-            self.coords.append(polygon)
+            if polygon:
+                self.coords.append(polygon)
 
     def mpoly(self):
         """Output of GeoJSON MultiPolygon object."""


### PR DESCRIPTION
… to coordinates collection

Sometimes contourf returns an empty polygon, if this is the case, the feature should not be added. Also, sometimes the polygon starts with an empty coordinates (path). If this is the case, the isobands won’t display in Leaflet