### PR TITLE
Fix: if contour had several separated areas of the same level contour…

### DIFF
--- a/geojsoncontour/contour.py
+++ b/geojsoncontour/contour.py
@@ -17,8 +17,8 @@ def contour_to_geojson(contour, geojson_filepath=None, min_angle_deg=None,
     line_features = []
     for collection in collections:
         color = collection.get_edgecolor()
-        for path in collection.get_paths():
-            v = path.vertices
+        for path in contour.allsegs[contour_index]:
+            v = path
             if len(v) < 3:
                 continue
             coordinates = keep_high_angle(v, min_angle_deg) if min_angle_deg else v


### PR DESCRIPTION
…_to_geojson extract it as single feature, so all your contours of one level was connected to each other. Use `contour.allsegs` instead of `collection.get_paths()` allows to extract every distinct region to independent feature.

I faced with such problem and this is my fix for it. Probably, it can be improved by combining each segment of one level to one feature of type _MultiLineString_ instead of independent _LineString_ features.